### PR TITLE
Fix mermaid diagram text readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ flowchart TD
     Download2 --> Done
 
     %% Styling
-    classDef errorStyle fill:#ffcccc,stroke:#cc0000,stroke-width:2px
-    classDef successStyle fill:#ccffcc,stroke:#00cc00,stroke-width:2px
-    classDef editStyle fill:#cce5ff,stroke:#0066cc,stroke-width:2px
-    classDef validateStyle fill:#fff4cc,stroke:#ccaa00,stroke-width:2px
+    classDef errorStyle fill:#ffcccc,stroke:#cc0000,stroke-width:2px,color:#000
+    classDef successStyle fill:#ccffcc,stroke:#00cc00,stroke-width:2px,color:#000
+    classDef editStyle fill:#cce5ff,stroke:#0066cc,stroke-width:2px,color:#000
+    classDef validateStyle fill:#fff4cc,stroke:#ccaa00,stroke-width:2px,color:#000
 
     class Error1,ErrorOverlap,ErrorConfig errorStyle
     class Generate,Download1,Download2,Done successStyle


### PR DESCRIPTION
## Summary

Fixes text readability in the Web App Workflow diagram by adding black text color to all colored boxes.

## Problem

The mermaid diagram in README.md had unreadable text in colored boxes because text color was not explicitly set, causing it to inherit light/gray colors that didn't contrast well with the colored backgrounds.

## Solution

Added `color:#000` (black text) to all `classDef` styles:
- Error boxes (red background) - Now have black text
- Success boxes (green background) - Now have black text
- Edit boxes (blue background) - Now have black text
- Validation boxes (yellow background) - Now have black text

## Changes

**Before:**
```
classDef errorStyle fill:#ffcccc,stroke:#cc0000,stroke-width:2px
```

**After:**
```
classDef errorStyle fill:#ffcccc,stroke:#cc0000,stroke-width:2px,color:#000
```

## Testing

- ✅ Verified mermaid syntax is valid
- ✅ Text is now readable on all colored backgrounds
- ✅ No other diagram changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)